### PR TITLE
Chmod o+w to folder with cache fontconfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN set -ex; \
     chmod -R 755 /var/www/html/*; \
     \
     rm -rf /tmp/*; \
-    fc-cache
+    chmod o+w /var/cache/fontconfig
 
 USER wodby
 


### PR DESCRIPTION
Fixes wodby/xhprof#5

Graphviz run as wodby, so rights are needed